### PR TITLE
ipython => jupyter

### DIFF
--- a/bin/iperl
+++ b/bin/iperl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # PODNAME: iperl
-# ABSTRACT: start ipython notebook with an IPerl kernel
+# ABSTRACT: start jupyter notebook with an IPerl kernel
 
 use strict;
 use warnings;
@@ -13,6 +13,8 @@ use File::Copy::Recursive qw(dircopy);
 use File::ShareDir::ProjectDistDir;
 use JSON::MaybeXS qw(encode_json);
 use Env qw(@PERL5LIB);
+
+my $jupyter = 'jupyter';
 
 main();
 
@@ -41,13 +43,13 @@ sub main {
 	if($ARGV[0] eq '--version') {
 		my $ipython_version = get_ipython_version();
 		my $devel_iperl_version = get_devel_iperl_version();
-		print STDERR "Devel::IPerl ($devel_iperl_version); IPython ($ipython_version)\n";
+		print STDERR "Devel::IPerl ($devel_iperl_version); Jupyter ($ipython_version)\n";
 		print STDERR "Devel/IPerl.pm: $INC{'Devel/IPerl.pm'}\n";
 		return 0;
 	}
 
 	# start IPython and specify which kernel we want
-	system("ipython", @ARGV, @kernel_args );
+	system($jupyter, @ARGV, @kernel_args );
 }
 
 sub get_devel_iperl_version {
@@ -62,7 +64,7 @@ sub get_devel_iperl_version {
 }
 
 sub get_ipython_version {
-	chomp( my $ipython_version = `ipython --version` );
+	chomp( my $ipython_version = `$jupyter --version` );
 	$ipython_version;
 }
 
@@ -71,7 +73,7 @@ sub get_kernels_template_dir {
 }
 
 sub get_ipython_target_dir {
-	my $ipython_dir = `ipython locate`;
+	my $ipython_dir = `$jupyter --data-dir`;
 	return if $!; # does not exist
 	chomp $ipython_dir;
 	return unless length $ipython_dir;


### PR DESCRIPTION
"ipython" is deprecated. We should use "jupyter". 