### PR TITLE
do not require Chart::Clicker

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,9 +9,13 @@ version = 0.006
 -bundle = @Basic
 -remove = ExtraTests
 
+[Prereqs / RuntimeRecommends]
+Chart::Clicker = 0
+
 [AutoPrereqs]
 skip = PDL
 skip = PDL::Graphics::Gnuplot
+skip = Chart::Clicker
 
 [MetaJSON]
 [PkgVersion]


### PR DESCRIPTION
This is a fix for #54 Chart::Clicker is a monster in terms of dependencies...
