### PR TITLE
- Fixed possible minor build error.

### DIFF
--- a/lib/Devel/IPerl/Message/ZMQ.pm
+++ b/lib/Devel/IPerl/Message/ZMQ.pm
@@ -1,4 +1,5 @@
 package Devel::IPerl::Message::ZMQ;
+
 use strict;
 use warnings;
 use Moo;


### PR DESCRIPTION
Hi @zmughal 

Please review the PR to fix the following error during build:

          [@Author::ZMUGHAL/@Author::ZMUGHAL::Basic/PkgVersion] no blank line for $VERSION after 
          package Devel::IPerl::Message::ZMQ

Many Thanks.
Best Regards,
Mohammad S Anwar