### PR TITLE
UTF-8 support for ::NBConvert

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -30,6 +30,7 @@ requires "Net::Async::ZMQ" => "0.002";
 requires "Net::Async::ZMQ::Socket" => "0";
 requires "PPI::Document" => "0";
 requires "Path::Class" => "0";
+requires "Path::Tiny" => "0";
 requires "Reply" => "0";
 requires "Reply::Plugin" => "0";
 requires "Scalar::Util" => "0";

--- a/lib/Devel/IPerl/NBConvert.pm
+++ b/lib/Devel/IPerl/NBConvert.pm
@@ -25,11 +25,14 @@ sub run {
 	my $file = shift @ARGV;
 	$self->notebook_file( path($file) );
 
-	my $data = decode_json( $self->notebook_file->slurp );
+	my $json = JSON::MaybeXS->new;
+	my $data = $json->decode( $self->notebook_file->slurp_utf8 );
 
 	my $output = $self->to_pod( $data );
 
-	print $output;
+	open(my $STDNEW, '>&', STDOUT);
+	binmode($STDNEW, ':encoding(UTF-8)');
+	print $STDNEW $output;
 }
 
 sub to_pod {
@@ -38,6 +41,8 @@ sub to_pod {
 	my $ansi_css = $self->ansi_css;
 
 	my $pod_string;
+
+	$pod_string .= "=encoding UTF-8\n";
 
 	for my $cell ( @{ $nb->{cells} } ) {
 		if( $cell->{cell_type} eq 'markdown' ) {

--- a/lib/Devel/IPerl/NBConvert.pm
+++ b/lib/Devel/IPerl/NBConvert.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use Getopt::Long;
 use Path::Class;
+use Path::Tiny;
 use JSON::MaybeXS;
 use Markdown::Pod;
 use HTML::FromANSI;
@@ -22,7 +23,7 @@ has output_to_stdout => ( is => 'rw' );
 sub run {
 	my ($self) = @_;
 	my $file = shift @ARGV;
-	$self->notebook_file( file($file) );
+	$self->notebook_file( path($file) );
 
 	my $data = decode_json( $self->notebook_file->slurp );
 


### PR DESCRIPTION
- Switch `::NBConvert` to `Path::Tiny`
- `::NBConvert` should use UTF-8 for input and output
